### PR TITLE
Only test on Linux to reduce CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
-  - push
-  - pull_request
+  - [push,  pull_request]
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -14,8 +13,8 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          #- macOS-latest
+          #- windows-latest
         arch:
           - x64
     steps:
@@ -55,8 +54,9 @@ jobs:
             Pkg.instantiate()'
       - run: |
           julia --project=docs -e '
-            using Documenter: doctest
+            using Documenter: DocMeta, doctest
             using LWFBrook90
+            DocMeta.setdocmeta!(LWFBrook90, :DocTestSetup, :(using LWFBrook90); recursive=true)
             doctest(LWFBrook90)'
       - run: julia --project=docs docs/make.jl
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
-  - [push,  pull_request]
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
Beside removing Win and Mac from CI tests, this PR combines the triggers of push and pull_requests together. 

Before this change a push to create a pull request in own repo triggered each test twice.