### PR TITLE
ci: Get CI running consistently

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.7'
           - 'nightly'
         os:
           - ubuntu-latest
-          #- macOS-latest
+          - macOS-latest
           #- windows-latest
         arch:
           - x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,10 @@ jobs:
           #- windows-latest
         arch:
           - x64
+        exclude:
+          - os: ubuntu-latest
+            version: '1.7'
+            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/test/03-regression-tests.jl
+++ b/test/03-regression-tests.jl
@@ -67,12 +67,13 @@ is_a_CI_system = issubset(["GITHUB_ACTION"], collect(keys(ENV))) # checks if ENV
         if !is_a_CI_system
             @test all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
         else
-            @test all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
+            @test_broken all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
         end
     elseif task == "overwrite" && !is_a_CI_system # only overwrite on local machine, never on CI
         jldsave(fname; u_ref);
     else
         # do nothing
+        @test_broken all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
     end
 
     if (false)
@@ -130,8 +131,8 @@ end
             @test        all(abs.((SWAT_d18O_ref .- loaded_SWAT_d18O_ref) ./ (loaded_SWAT_d18O_ref .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
             @test        all(abs.((SWAT_d2H_ref  .- loaded_SWAT_d2H_ref ) ./ (loaded_SWAT_d2H_ref  .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
         else
-            @test all(abs.((SWAT_d18O_ref .- loaded_SWAT_d18O_ref) ./ (loaded_SWAT_d18O_ref .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
-            @test all(abs.((SWAT_d2H_ref  .- loaded_SWAT_d2H_ref ) ./ (loaded_SWAT_d2H_ref  .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
+            @test_broken all(abs.((SWAT_d18O_ref .- loaded_SWAT_d18O_ref) ./ (loaded_SWAT_d18O_ref .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
+            @test_broken all(abs.((SWAT_d2H_ref  .- loaded_SWAT_d2H_ref ) ./ (loaded_SWAT_d2H_ref  .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
         end
     elseif task == "overwrite" && !is_a_CI_system # only overwrite on local machine, never on CI
         # overwrite output

--- a/test/03-regression-tests.jl
+++ b/test/03-regression-tests.jl
@@ -67,13 +67,12 @@ is_a_CI_system = issubset(["GITHUB_ACTION"], collect(keys(ENV))) # checks if ENV
         if !is_a_CI_system
             @test all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
         else
-            @test_broken all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
+            @test all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
         end
     elseif task == "overwrite" && !is_a_CI_system # only overwrite on local machine, never on CI
         jldsave(fname; u_ref);
     else
         # do nothing
-        @test_broken all(abs.((u_ref  .- loaded_u_ref) ./ (loaded_u_ref  .+ eps(Float64))) .< 1e-3) # adding eps for values where _ref is zero
     end
 
     if (false)
@@ -131,8 +130,8 @@ end
             @test        all(abs.((SWAT_d18O_ref .- loaded_SWAT_d18O_ref) ./ (loaded_SWAT_d18O_ref .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
             @test        all(abs.((SWAT_d2H_ref  .- loaded_SWAT_d2H_ref ) ./ (loaded_SWAT_d2H_ref  .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
         else
-            @test_broken all(abs.((SWAT_d18O_ref .- loaded_SWAT_d18O_ref) ./ (loaded_SWAT_d18O_ref .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
-            @test_broken all(abs.((SWAT_d2H_ref  .- loaded_SWAT_d2H_ref ) ./ (loaded_SWAT_d2H_ref  .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
+            @test all(abs.((SWAT_d18O_ref .- loaded_SWAT_d18O_ref) ./ (loaded_SWAT_d18O_ref .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
+            @test all(abs.((SWAT_d2H_ref  .- loaded_SWAT_d2H_ref ) ./ (loaded_SWAT_d2H_ref  .+ eps(Float64))) .< 1e-5) # adding eps for values where _ref is zero
         end
     elseif task == "overwrite" && !is_a_CI_system # only overwrite on local machine, never on CI
         # overwrite output


### PR DESCRIPTION
ci: Add macOS and Julia 1.7, remove Julia 1.6

As we still have discrepancies between local and CI testing check if it
is related to the architecture and Julia versions.

Nightly version on ubuntu is passing. Local testing happens on macOS and
Julia 1.7.2