### PR TITLE
docs: Force to use Julia 1.9

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.9'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/docs/src/function-docs.md
+++ b/docs/src/function-docs.md
@@ -21,7 +21,8 @@ Pages   = ["LWFBrook90.jl"]
 Modules = [LWFBrook90]
 Pages   = ["func_read_inputData.jl",
            "func_discretize_soil_domain.jl",
-           "func_postprocess.jl"]
+           "func_postprocess.jl",
+           "generate_LWFBrook90R_Input.jl"]
 ```
 
 ## Functions defining the DiffEq.jl system of ODE (p, u0, f, callbacks, ...)


### PR DESCRIPTION
The following reply to a Documenter Issue:
https://github.com/JuliaDocs/Documenter.jl/issues/2206#issuecomment-1872603089

Links this problem to Documenter Syntax that works with Julia 1.9 but not with 1.10.
As a hotfix, we force the use of version 1.9.
This pull request remains open to fix the underlying cause.